### PR TITLE
Sync download translations with English master and set correct encodings

### DIFF
--- a/download.de.rst
+++ b/download.de.rst
@@ -4,36 +4,41 @@ Download
 
 .. Note::
 
-   Die 'Nightly Builds', die Du am Ende dieser Seite findest, sind nur für Entwickler und Tester
-   gedacht. Die 'Nightly Builds' sind nicht für Anwender konfiguriert,
-   sie sind manchmal instabil und es fehlen die ganzen Programme, die
-   die Verwendung von AROS für Endbenutzer interessant machen.
+   Die Nightly Builds sind nur fr Entwickler und Tester gedacht. Die Nightly
+   Builds sind nicht fr eine einfache Nutzung eingerichtet, sind nicht immer
+   stabil und es fehlen die meisten Anwendungen, die fr eine normale
+   Benutzererfahrung wichtig sind.
 
 .. Contents::
 
 Nightly Builds
 ======================
 
-`Nightly builds`__ werden, wie der Name sagt, jede Nacht aus dem aktuellen
-Sourcecode vom Subversionbaum erstellt. Sie wurden jedoch nicht getestet
-und können Fehler enthalten. Meistens funktionieren sie aber ganz gut.
+Nightly Builds werden, wie der Name sagt, jede Nacht direkt aus dem
+Git-Repository erstellt und enthalten den neuesten Code. Sie wurden jedoch
+in keiner Weise getestet und knnen Fehler enthalten. Meistens funktionieren
+sie aber ganz gut. `Download link`__
 
-Diese Builds sind auf Quellen der neuen `ABI`__ aufgebaut. **Sie sind nicht kompatibel mit alten AROS-Distributionen/Forks.**
+Diese Builds basieren auf den Quellen der neuen `ABI`__. **Sie sind nicht
+kompatibel mit alten AROS-Distributionen/Forks.**
 
-Berichte bitte Fehler, die dir beim Testen auffallen, an den `Bug Tracker`__.
-Verwende bitte für Diskussionen das `AROS-Exec`__ Forum.
+Bitte melde Fehler, die du bei der Nutzung dieser Builds entdeckst, ber den
+`issue tracker`__.
 
 __ nightly1
-__ https://de.wikipedia.org/wiki/Bin%C3%A4rschnittstelle
-__ http://sourceforge.net/p/aros/bugs/
+__ https://en.wikipedia.org/wiki/Application_binary_interface
+__ https://github.com/aros-development-team/AROS/issues
 
 
 Snapshots
 =================
 
-`Snapshots`__ sind unregelmäßige, nicht automatisierte Builds von AROS. Sie wurden
-von Entwicklern erzeugt, die aus irgend einem Grund keine Nightly Builds erstellen
-können. Sie sind nicht ungewartet, deshalb berichte bitte Fehler an den `Bug Tracker`__.
+Snapshots sind unregelmige, nicht automatisierte Builds von AROS. Sie werden
+von Entwicklern erstellt, die aus irgendeinem Grund keine Nightly Builds
+einrichten knnen. `Download link`__
+
+Diese Ports werden nicht eingestellt, daher nutze bitte den `issue tracker`__,
+um Fehler zu melden.
 
 __ snapshots1
-__ http://sourceforge.net/p/aros/bugs/
+__ https://github.com/aros-development-team/AROS/issues

--- a/download.it.rst
+++ b/download.it.rst
@@ -1,52 +1,44 @@
 ========
 Download
 ========
+
 .. Note::
 
-   The nightly builds are only meant for developers and testers. The nightly
-   builds are not configured to be easily used, are not always stable, and
-   they are missing most of the applications essential to a regular user experience.
+   Le nightly build sono destinate solo a sviluppatori e tester. Le nightly
+   build non sono configurate per un uso semplice, non sono sempre stabili e
+   mancano della maggior parte delle applicazioni essenziali per un'esperienza
+   utente regolare.
 
 .. Contents::
 
+Nightly Builds
+======================
+
+Le nightly build vengono create, come suggerisce il nome, ogni notte
+direttamente dal repository Git e contengono il codice pi recente. Tuttavia
+non sono state testate in alcun modo e possono contenere bug. La maggior parte
+delle volte, per, funzionano senza problemi. `Link per il download`__
+
+Queste build si basano sui sorgenti della nuova `ABI`__. **Non sono compatibili
+con le vecchie distribuzioni/fork di AROS.**
+
+Segnala eventuali bug che scopri durante l'uso di queste build tramite
+l'`issue tracker`__.
+
+__ nightly1
+__ https://en.wikipedia.org/wiki/Application_binary_interface
+__ https://github.com/aros-development-team/AROS/issues
+
+
 Snapshots
-=========
+=================
 
-Le snapshots sono build di AROS non automate e non periodiche. Sono fatte da
-sviluppatori che non riescono ad usare una nightly build correttamente per
-ragioni tecniche o politiche
+Le snapshot sono build di AROS non periodiche e non automatizzate. Vengono
+realizzate da sviluppatori che per qualche motivo non possono configurare una
+nightly build. `Link per il download`__
 
-Questi ports sono mantenuti, quindi se volete segnalare bug e problemi usate
-il `bug tracker`__.
+Questi port non sono abbandonati, quindi usa l'`issue tracker`__ per segnalare
+i bug.
 
-.. raw:: html
-
-   <?php virtual( "/cgi-bin/files?type=snapshots&lang=en" ); ?>
-
-__ http://sourceforge.net/p/aros/bugs/
-
-
-Nightly build
-=============
-
-.. Nota::
-
-   Per scaricare correttamente una nightly build, consigliamo vivamente 
-   l'uso di un download manager che possa recuperare un download 
-   interrotto, oppure il comando wget (con "wget -c" per scaricare la 
-   porzione rimanente di un file già scaricato in parte da un altro 
-   programma).
-
-Le nightly build vengono create automaticamente ogni notte a partire 
-dal codice sorgente più aggiornato. Siccome si tratta di versioni in 
-piena fase di sviluppo, è possibile che non si compilino o che non funzionino
-correttamente. Per cortesia, se trovate errori segnalateceli attraverso lo
-strumento apposito, il `bug tracker`__.
-
-.. raw:: html
-
-   <?php virtual( "/cgi-bin/files?type=nightly&lang=it" ); ?>
-
-__ http://sourceforge.net/p/aros/bugs/
-
-
+__ snapshots1
+__ https://github.com/aros-development-team/AROS/issues

--- a/download.nl.rst
+++ b/download.nl.rst
@@ -4,42 +4,40 @@ Download
 
 .. Note::
 
-   De nachtelijke compilaties, die zich onderaan deze pagina bevinden, zijn
-   alleen bedoeld voor ontwikkelaars en testers. De nachtelijke compilaties
-   zijn niet geconfigureerd voor eenvoudig gebruik, zijn niet altijd stabiel
-   en missen de meeste applicaties die noodzakelijk zijn voor een normale
-   gebruikerservaring.
+   De nightly builds zijn alleen bedoeld voor ontwikkelaars en testers. De
+   nightly builds zijn niet geconfigureerd voor eenvoudig gebruik, zijn niet
+   altijd stabiel en missen de meeste applicaties die essentieel zijn voor een
+   normale gebruikerservaring.
 
 .. Contents::
 
+Nightly Builds
+======================
+
+Nightly builds worden, zoals de naam aangeeft, elke nacht rechtstreeks uit de
+Git-repository gemaakt en bevatten de nieuwste code. Ze zijn echter niet getest
+en kunnen bugs bevatten. Meestal werken ze echter prima. `Downloadlink`__
+
+Deze builds zijn gebaseerd op bronnen van de nieuwe `ABI`__. **Ze zijn niet
+n-op-n compatibel met oude AROS-distributies/forks.**
+
+Meld bugs die je tijdens het gebruik van deze builds ontdekt via de
+`issue tracker`__.
+
+__ nightly1
+__ https://en.wikipedia.org/wiki/Application_binary_interface
+__ https://github.com/aros-development-team/AROS/issues
+
 
 Snapshots
-=========
+=================
 
-`Snapshots`__ zijn niet-periodieke, ongeautomatiseerde compilaties van AROS.
-Ze worden gemaakt door ontwikkelaars die, om wat voor reden dan ook, geen
-nachtelijke compilaties kunnen realiseren.
+Snapshots zijn niet-periodieke, niet-geautomatiseerde builds van AROS. Ze worden
+gemaakt door ontwikkelaars die om wat voor reden dan ook geen nightly build
+kunnen opzetten. `Downloadlink`__
 
-Deze compilaties worden onderhouden, dus gebruik a.u.b. de `bug tracker`__ om
-fouten te rapporteren.
+Deze ports zijn niet verlaten, dus gebruik de `issue tracker`__ om bugs te
+melden.
 
-__ snapshots
-__ http://sourceforge.net/p/aros/bugs/
-
-
-Nachtelijke Compilaties
-===============================
-
-AROS zit momenteel in een overgangsperiode naar een nieuwe `ABI`__. Een
-aanvullend aantal nachtelijke compilaties worden gemaakt op basis van
-deze experimentele bronbestanden, maar `deze compilaties`__ zijn alleen
-nuttig voor ontwikkelaars die de voortgang van de ABI-overgang willen
-controleren. **Ze zijn niet uitwisselbaar met de bestaande AROS
-distributies of met de AROS software die beschikbaar is via The AROS
-Archives of Aminet.**
-Gebruikers die nieuwe functionaliteit of foutreparaties zouden willen
-uitproberen die nog niet beschikbaar zijn in de distributies dienen
-alleen de gebruikelijke nachtelijke compilaties te gebruiken.
-
-__ http://en.wikipedia.org/wiki/Application_binary_interface
-__ nightly1
+__ snapshots1
+__ https://github.com/aros-development-team/AROS/issues

--- a/download.ru.rst
+++ b/download.ru.rst
@@ -4,25 +4,25 @@ Download
 
 .. Note::
 
-   The nightly builds are only meant for developers and testers. The nightly
-   builds are not configured to be easily used, are not always stable, and
-   they are missing most of the applications essential to a regular user experience.
+          . 
+        ,      
+     ,   .
 
 .. Contents::
 
 Nightly Builds
 ======================
 
-Nightly builds are done, as the name implies, every night, directly
-from the Git repository, and they contain the latest code. However,
-they have not been tested in any way and may contain bugs. Most of the
-time, though, they work just fine. `Download link`__
+ ,    ,     
+ Git     .      
+  .         .
+`  `__
 
-These builds are based on sources of the new `ABI`__. **They are not
-compatible with old AROS distributions/forks.**
+      `ABI`__. **   
+/ AROS.**
 
-Please report bugs you may discover while using these builds through the
-`issue tracker`__. 
+,   ,      
+,  `issue tracker`__.
 
 __ nightly1
 __ https://en.wikipedia.org/wiki/Application_binary_interface
@@ -32,12 +32,12 @@ __ https://github.com/aros-development-team/AROS/issues
 Snapshots
 =================
 
-Snapshots are non-periodic, non-automated builds of AROS. They are done
-by developers who can't set up a nightly build for some reason.
-`Download link`__
+ (snapshots)   ,   AROS.
+  ,   -     
+. `  `__
 
-These ports are not unmaintained, so please use the `issue tracker`__ to report
-bugs.
+   ,   `issue tracker`__   
+.
 
 __ snapshots1
 __ https://github.com/aros-development-team/AROS/issues

--- a/download.sv.rst
+++ b/download.sv.rst
@@ -1,42 +1,44 @@
 ===========
-Nerladdning
+Nedladdning
 ===========
 
 .. Note::
 
-   "Nightly builds" (nattkompilationer), som du hittar längst ner, är enbart
-   till för utvecklare och testare. Nightly builds är inte enkla att använda,
-   är inte alltid stabila och de saknar de flesta program som en vanlig
-   användare troligen skulle efterfråga.
+   Nightly builds r bara avsedda fr utvecklare och testare. Nightly builds r
+   inte konfigurerade fr att vara enkla att anvnda, r inte alltid stabila och
+   saknar de flesta program som r ndvndiga fr en vanlig
+   anvndarupplevelse.
 
 
 .. Contents::
 
-Snapshots
-=========
-
-`Snapshots`__ är icke regelbundet utgivna och icke automatiserade versioner
-av AROS. De är skapade av utvecklare som av någon anledning inte kan använda
-sig av vanliga nightly builds.
-
-Dessa versioner är inte övergivna, så använd den vanliga kanalen för att
-rapportera buggar (`bug tracker`__).
-
-__ snapshots
-__ http://sourceforge.net/p/aros/bugs/
-
-
 Nightly Builds
 ======================
 
-AROS håller på att övergå till en ny `ABI`__. En egen uppsättning nightly
-builds har skapats för denna experimentella källkod, men `dessa`__ är bara
-användbara för utvecklare som vill hålla sig uppdaterade om ABI-övergången.
-**AVIv1 är inte kompatibel med någon distribution eller AROS-mjukvara från
-AROS Archives eller Aminet.** Användare som vill testa nyheter och buggfixade
-versioner av AROS som ännu inte implementerats i distributionerna bör endast
-använda de vanliga nightly builds.
+Nightly builds grs, som namnet antyder, varje natt direkt frn Git-repot och
+innehller den senaste koden. De har dock inte testats p ngot stt och kan
+innehlla buggar. Oftast fungerar de nd bra. `Nedladdningslnk`__
 
-__ http://en.wikipedia.org/wiki/Application_binary_interface
+Dessa builds r baserade p kllorna till nya `ABI`__. **De r inte kompatibla
+med gamla AROS-distributioner/frgreningar.**
+
+Rapportera fel som du upptcker nr du anvnder dessa builds via
+`issue tracker`__.
+
 __ nightly1
+__ https://en.wikipedia.org/wiki/Application_binary_interface
+__ https://github.com/aros-development-team/AROS/issues
 
+
+Snapshots
+=================
+
+Snapshots r icke-periodiska, icke-automatiserade builds av AROS. De grs av
+utvecklare som av ngon anledning inte kan stta upp en nightly build.
+`Nedladdningslnk`__
+
+Dessa portar r inte vergivna, s anvnd `issue tracker`__ fr att rapportera
+buggar.
+
+__ snapshots1
+__ https://github.com/aros-development-team/AROS/issues


### PR DESCRIPTION
### Motivation
- Keep translated `download.*.rst` pages consistent with the English master so structure, links and references remain correct.
- Ensure each translation file uses the intended non-UTF-8 encoding for its locale to avoid rendering or link breakage in legacy toolchains.

### Description
- Updated content in `download.de.rst`, `download.it.rst`, `download.nl.rst`, `download.ru.rst`, and `download.sv.rst` to match the English `download.en.rst` structure and link targets.
- Standardised issue tracker and ABI links across translations to use the English `Application binary interface` and the GitHub issues URL.
- Re-encoded files per locale: German/Italian/Dutch/Swedish → `iso-8859-1` and Russian → `cp1251`.
- Removed or replaced fragile includes/raw HTML in favour of the synchronized, localized text so links and references are not broken.

### Testing
- Ran Python-based encoding detection to list which `download.*.rst` files decoded as UTF-8 and which did not, and used encoding-specific reads to validate content after re-encoding, with checks passing.
- Printed preview excerpts of each modified file using the chosen encoding to verify text and link presence, which matched the English structure.
- Searched repository text for encoding-related patterns to confirm the intended encodings are compatible with the existing build scripts, with no regressions found.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f2965ec0c83298018346b266acb0c)