### PR TITLE
Fix localized 'Read more' text and Russian heading encoding

### DIFF
--- a/index.ru.rst
+++ b/index.ru.rst
@@ -8,7 +8,7 @@
 
 .. Include:: introduction/index-abstract.ru.rst
 
-`Read more... <introduction/index>`__
+`Подробнее... <introduction/index>`__
 
 .. raw:: html
 
@@ -16,7 +16,7 @@
 
    <section>
 
-   <h1>Ð ÐµÑÑƒÑ€ÑÑ‹ ÑÐ¾Ð¾Ð±Ñ‰ÐµÑÑ‚Ð²Ð°, Ñ„Ð¾Ñ€ÐºÐ¸ Ð¸ Ð°Ñ‚Ñ€Ð¸Ð±ÑƒÑ†Ð¸Ñ<br><img style="width: 238px; height: 2px;" alt="spacer" src="/images/sidespacer.png"></h1>
+   <h1>Ресурсы сообщества, форки и атрибуция<br><img style="width: 238px; height: 2px;" alt="spacer" src="/images/sidespacer.png"></h1>
 
 .. Include:: attribution-abstract.ru.rst
 

--- a/index.sv.rst
+++ b/index.sv.rst
@@ -8,7 +8,7 @@
 
 .. Include:: introduction/index-abstract.sv.rst
 
-`Read more... <introduction/index>`__
+`Läs mer... <introduction/index>`__
 
 .. raw:: html
 


### PR DESCRIPTION
### Motivation
- Ensure the front-page text displays correct localized "Read more..." strings and fix a mis-encoded Russian heading so translations render properly for Russian and Swedish users.

### Description
- Updated `index.ru.rst` to replace `Read more...` with `Подробнее...` and corrected the Russian heading to `Ресурсы сообщества, форки и атрибуция`, and updated `index.sv.rst` to replace `Read more...` with `Läs mer...`.

### Testing
- No automated tests were run because these are static text and encoding fixes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f32cec4848329990e7f3d5149a6ac)